### PR TITLE
Fix the `LIKE` SQL of the previous commit

### DIFF
--- a/inc/plugins/mybbfancybox.php
+++ b/inc/plugins/mybbfancybox.php
@@ -347,7 +347,7 @@ function mybbfancybox_uninstall()
 	update_theme_stylesheet_list(1, false, true);
 
 	// Delete plugin settings in ACP
-	$db->write_query("DELETE FROM ".TABLE_PREFIX."settings WHERE name LIKE 'mybbfancybox_%'");
+	$db->write_query("DELETE FROM ".TABLE_PREFIX."settings WHERE name LIKE 'mybbfancybox\\_%'");
 	$db->write_query("DELETE FROM ".TABLE_PREFIX."settinggroups WHERE name = 'mybbfancybox'");
 
 	// Rebuild settings


### PR DESCRIPTION
As pointed out by @effone, the underscore is a special character in this context which requires escaping:

https://github.com/mybbgroup/FancyBox/pull/79#discussion_r560114520